### PR TITLE
fix miniv

### DIFF
--- a/forge16/src/main/java/com/envyful/specs/forge/spec/MinIVsRequirement.java
+++ b/forge16/src/main/java/com/envyful/specs/forge/spec/MinIVsRequirement.java
@@ -17,11 +17,11 @@ public class MinIVsRequirement extends AbstractIntegerPokemonRequirement {
     );
 
     public MinIVsRequirement() {
-        super(KEYS, 50);
+        super(KEYS, 0);
     }
 
     public MinIVsRequirement(int value) {
-        super(KEYS, 50, value);
+        super(KEYS, 0, value);
     }
 
     @Override
@@ -36,32 +36,22 @@ public class MinIVsRequirement extends AbstractIntegerPokemonRequirement {
 
     @Override
     public void applyData(Pokemon pokemon) {
-        this.calculateIVs().whenComplete((ivs, error) -> pokemon.getIVs().fillFromArray(ivs));
+        this.calculateIVs(pokemon.getIVs().getArray()).whenComplete((ivs, error) -> pokemon.getIVs().fillFromArray(ivs));
     }
 
-    private CompletableFuture<int[]> calculateIVs() {
-        if (this.value == 100) {
+    private CompletableFuture<int[]> calculateIVs(int[] currentIvs) {
+        if (this.value >= 100) {
             return CompletableFuture.completedFuture(new int[] {31, 31, 31, 31, 31, 31});
         }
 
         return CompletableFuture.supplyAsync(() -> {
-            int[] ivs = new int[6];
+        	IVStore ivs = IVStore.createRandomNewIVs();
 
-            for (int i = 0; i < 5; i++) {
-                ivs[i] = (int) (31 * (this.value / 100.00));
+            while (this.calculateIVPercentage(ivs.getArray()) < this.value) {
+            	ivs = IVStore.createRandomNewIVs();
             }
 
-            while (this.calculateIVPercentage(ivs) <= this.value) {
-                int slot = UtilRandom.randomInteger(0, 5);
-
-                if (ivs[slot] == 31) {
-                    continue;
-                }
-
-                ivs[slot]++;
-            }
-
-            return ivs;
+            return ivs.getArray();
         });
     }
 


### PR DESCRIPTION
Dear maintainer,

I have received a request to fix min IV on your plugin, and I have implemented a solution that I would like to share with you through this pull request.

To ensure that we fully respect the concept of min IV, I have made the following changes:

    If no value is set, the base value for min IV is now set to 0. This allows for a range from 0 to 100, as intended.
    If a value is set, IVs will no longer be the exact value, but rather the value or more. This ensures that the minimum IV value is met or exceeded.

I believe that these changes will improve the functionality of your plugin and help to ensure that it is used as intended.

Thank you for considering my contribution, and have a great day.

Sincerely,
Mateget